### PR TITLE
add cmd/hexd/hexd.go, and fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ hexd.WriteTo(w io.Writer, b []byte) (n int, err error)
 To start using `hexd`, install Go and run go get:
 
 ```
-$ go get -u github.com/tidwall/hexd
+$ go get -u github.com/tidwall/hexd/cmd/hexd
 ```
 
 This will retrieve the library.

--- a/cmd/hexd/hexd.go
+++ b/cmd/hexd/hexd.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/tidwall/hexd"
+)
+
+func readBytes() []byte {
+	if len(os.Args) > 1 {
+		data, err := ioutil.ReadFile(os.Args[1])
+		if err != nil {
+			panic(err)
+		}
+		return data
+	}
+	data, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func main() {
+	fmt.Println(hexd.DumpString(readBytes()))
+}


### PR DESCRIPTION
There was no main package/function, so `go get` would not install any binary